### PR TITLE
chore: add the hashicorp-tools image as updatecli parameter to use terraform version 1.1.x

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -13,9 +13,9 @@ parallel(
     )
   },
   'updatecli': {
-    updatecli(action: 'diff')
+    updatecli(action: 'diff', updatecliDockerImage: 'jenkinsciinfra/hashicorp-tools:0.4.1')
     if (env.BRANCH_IS_PRIMARY) {
-      updatecli(action: 'apply', cronTriggerExpression: '@weekly')
+      updatecli(action: 'apply', cronTriggerExpression: '@weekly', updatecliDockerImage: 'jenkinsciinfra/hashicorp-tools:0.4.1')
     }
   },
 )

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0, <1.1"
+  required_version = ">= 1.1, <1.2"
   required_providers {
     digitalocean = {
       source  = "digitalocean/digitalocean"


### PR DESCRIPTION
as per https://github.com/jenkins-infra/shared-tools/issues/8
use of the terraform 1.2.x within the hashicorp docker image 