### PR TITLE
chore: keep track of hashicorp-version with updatecli

### DIFF
--- a/updatecli/updatecli.d/hashicorp.yml
+++ b/updatecli/updatecli.d/hashicorp.yml
@@ -48,3 +48,4 @@ pullrequests:
     spec:
       labels:
         - dependencies
+        - hashicorp-tools

--- a/updatecli/updatecli.d/hashicorp.yml
+++ b/updatecli/updatecli.d/hashicorp.yml
@@ -1,0 +1,50 @@
+title: Bump Jenkinsfile_k8s for updatecli `hashicorp-tools` docker image version to lastest image release
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  dockerHashicorpToolsImageVersion:
+    kind: githubRelease
+    spec:
+      owner: "jenkins-infra"
+      repository: "docker-hashicorp-tools"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+
+conditions:
+  checkIfDockerImageIsPublished:
+    name: "Check if the Docker Image is published"
+    kind: dockerImage
+    spec:
+      image: "jenkinsciinfra/hashicorp-tools"
+      architecture: amd64
+
+targets:
+  updateJenkinsfile:
+    name: Update jenkinsfile_k8s file in groovy code
+    kind: file
+    spec:
+      file: ./Jenkinsfile_k8s
+      matchpattern: 'jenkinsciinfra/hashicorp-tools:(.*)'
+      replacepattern: 'jenkinsciinfra/hashicorp-tools:{{ source `dockerHashicorpToolsImageVersion` }}'
+    scmID: default
+
+pullrequests:
+  default:
+    kind: github
+    scmID: default
+    targets:
+      - updateJenkinsfile
+    spec:
+      labels:
+        - dependencies


### PR DESCRIPTION
as per https://github.com/jenkins-infra/aws/issues/120
keep track of the hashicorp tools image version