### PR TITLE
fix: hardcode k8s version until the switch to 1.21

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,4 @@ override.tf.json
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 **tfplan*
-terraform-plan-output.txt
+terraform-plan-*.txt

--- a/autoscaled-node-pool.tf
+++ b/autoscaled-node-pool.tf
@@ -6,4 +6,11 @@ resource "digitalocean_kubernetes_node_pool" "autoscaled-pool" {
   min_nodes  = 1
   max_nodes  = var.autoscaled_node_pool_max_nodes
   tags       = ["node-pool-autoscaled", local.cluster_name]
+  lifecycle {
+    ignore_changes = [
+      node_count,
+      actual_node_count,
+      nodes,
+    ]
+  }
 }

--- a/doks-cluster.tf
+++ b/doks-cluster.tf
@@ -4,9 +4,11 @@ resource "digitalocean_kubernetes_cluster" "doks_cluster" {
   version       = local.doks_version
   auto_upgrade  = var.auto_upgrade
   surge_upgrade = true
+  tags          = ["managed-by", "terraform"]
   lifecycle {
     ignore_changes = [
-      version
+      version,
+      updated_at,
     ]
   }
 

--- a/locals.tf
+++ b/locals.tf
@@ -5,6 +5,9 @@ resource "random_string" "suffix" {
 
 locals {
   cluster_name           = lower("jenkins-infra-doks-${random_string.suffix.result}")
-  doks_version           = data.digitalocean_kubernetes_versions.k8s.latest_version
+  # `doctl kubernetes options versions` doesn't return anything if the linor k8s version isn't suported anymore.
+  # hardoding the version until we switch to Kubernetes 1.21
+  doks_version           = "1.20.15-do.1"
+  # doks_version           = data.digitalocean_kubernetes_versions.k8s.latest_version
   minimal_node_pool_size = "s-1vcpu-2gb" # Available sizes: `doctl compute size list`
 }

--- a/variables.tf
+++ b/variables.tf
@@ -6,8 +6,8 @@ variable "region" {
 
 variable "kubernetes_version" {
   type        = string
-  default     = "1.20"
-  description = "Kubernetes version in format '<MINOR>.<MINOR>'"
+  default     = "1.20."
+  description = "Kubernetes version in format '<MINOR>.<MINOR>.'"
 }
 
 variable "autoscaled_node_pool_size" {


### PR DESCRIPTION
`doctl kubernetes options versions` doesn't return anything for 1.20.x any more.
Ref: https://github.com/jenkins-infra/helpdesk/issues/2861