### PR TITLE
Enable digitalocean job again

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,5 +1,3 @@
-/**
-
 def dockerImage = 'jenkinsciinfra/hashicorp-tools:0.5.5' // Tracked by updatecli
 
 parallel(
@@ -25,5 +23,3 @@ parallel(
     }
   },
 )
-
-**/


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/2884.

- GitHub checks have been disabled on infra.ci - https://github.com/jenkins-infra/kubernetes-management/pull/2245
- Credentials rotated (private: https://github.com/jenkins-infra/charts-secrets/commit/3701045ae7e21df2a37ebd0c570e4315b4200f74)

This PR enables the terraform job again: it should create a brand new cluster once merged.