### PR TITLE
feat: disable the autoscaled-node-pool

### DIFF
--- a/autoscaled-node-pool.tf
+++ b/autoscaled-node-pool.tf
@@ -1,16 +1,17 @@
-resource "digitalocean_kubernetes_node_pool" "autoscaled-pool" {
-  cluster_id = digitalocean_kubernetes_cluster.doks_cluster.id
-  name       = "autoscaled-node-pool"
-  size       = var.autoscaled_node_pool_size
-  auto_scale = true
-  min_nodes  = 1
-  max_nodes  = var.autoscaled_node_pool_max_nodes
-  tags       = ["node-pool-autoscaled", local.cluster_name]
-  lifecycle {
-    ignore_changes = [
-      node_count,
-      actual_node_count,
-      nodes,
-    ]
-  }
-}
+## Disabled as per https://github.com/jenkins-infra/helpdesk/issues/2917
+# resource "digitalocean_kubernetes_node_pool" "autoscaled-pool" {
+#   cluster_id = digitalocean_kubernetes_cluster.doks_cluster.id
+#   name       = "autoscaled-node-pool"
+#   size       = var.autoscaled_node_pool_size
+#   auto_scale = true
+#   min_nodes  = 1
+#   max_nodes  = var.autoscaled_node_pool_max_nodes
+#   tags       = ["node-pool-autoscaled", local.cluster_name]
+#   lifecycle {
+#     ignore_changes = [
+#       node_count,
+#       actual_node_count,
+#       nodes,
+#     ]
+#   }
+# }


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/2917, this change request disables the autoscaled node pool.

The goal is to keep the cluster running, but without any beefy machine, until we can be sure if we continue using digital ocean or if we stop it.