### PR TITLE
kubernetes upgrade from 1.21 to 1.22

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -6,7 +6,7 @@ variable "region" {
 
 variable "kubernetes_version" {
   type        = string
-  default     = "1.21."
+  default     = "1.22."
   description = "Kubernetes version in format '<MAJOR>.<MINOR>.'"
 }
 


### PR DESCRIPTION
as per : https://github.com/jenkins-infra/helpdesk/issues/2930
upgrade kubernetes from 1.21 to 1.22 

```
Changes to Outputs:
  ~ dok8s-versions = [
      - "1.21.11-do.1",
      + "1.22.8-do.1",
    ]

You can apply this plan to save these new output values to the Terraform
state, without changing any real infrastructure.
```