### PR TITLE
feat: public cluster

### DIFF
--- a/doks-public-cluster.tf
+++ b/doks-public-cluster.tf
@@ -16,12 +16,13 @@ resource "digitalocean_kubernetes_cluster" "doks_public_cluster" {
     day        = var.maintenance_policy_day
   }
 
-  # Small node pool without autoscalling.
+  # Small node pool with autoscalling
   node_pool {
     name       = "minimal-node-pool"
     size       = local.minimal_node_pool_size
-    auto_scale = false
-    node_count = local.public_cluster_minimal_node_count
+    auto_scale = true
+    min_nodes  = 1
+    max_nodes  = var.autoscaled_node_pool_max_nodes
     tags       = ["node-pool-minimal", local.cluster_name]
   }
 }

--- a/doks-public-cluster.tf
+++ b/doks-public-cluster.tf
@@ -18,11 +18,11 @@ resource "digitalocean_kubernetes_cluster" "doks_public_cluster" {
 
   # Small node pool with autoscalling
   node_pool {
-    name       = "minimal-node-pool"
+    name       = "small-node-pool"
     size       = local.minimal_node_pool_size
     auto_scale = true
     min_nodes  = 1
     max_nodes  = var.autoscaled_node_pool_max_nodes
-    tags       = ["node-pool-minimal", local.cluster_name]
+    tags       = ["node-pool-small", local.public_cluster_name]
   }
 }

--- a/doks-public-cluster.tf
+++ b/doks-public-cluster.tf
@@ -1,0 +1,30 @@
+resource "digitalocean_kubernetes_cluster" "doks_public_cluster" {
+  name          = local.public_cluster_name
+  region        = var.region
+  version       = local.doks_version
+  auto_upgrade  = var.auto_upgrade
+  surge_upgrade = true
+  tags          = ["managed-by:terraform"]
+  lifecycle {
+    ignore_changes = [
+      updated_at,
+    ]
+  }
+
+  maintenance_policy {
+    start_time = var.maintenance_policy_start_time
+    day        = var.maintenance_policy_day
+  }
+
+  # Small node pool without autoscalling.
+  # As we can't scale to 0 with DO, we're setting up 2 node pools:
+  # - this one with the minimal size and no heavy usage
+  # - another beefy one with autoscalling enabled, see ./autoscaled-node-pool.tf
+  node_pool {
+    name       = "minimal-node-pool"
+    size       = local.minimal_node_pool_size
+    auto_scale = false
+    node_count = 1
+    tags       = ["node-pool-minimal", local.cluster_name]
+  }
+}

--- a/doks-public-cluster.tf
+++ b/doks-public-cluster.tf
@@ -17,14 +17,11 @@ resource "digitalocean_kubernetes_cluster" "doks_public_cluster" {
   }
 
   # Small node pool without autoscalling.
-  # As we can't scale to 0 with DO, we're setting up 2 node pools:
-  # - this one with the minimal size and no heavy usage
-  # - another beefy one with autoscalling enabled, see ./autoscaled-node-pool.tf
   node_pool {
     name       = "minimal-node-pool"
     size       = local.minimal_node_pool_size
     auto_scale = false
-    node_count = 1
+    node_count = local.public_cluster_minimal_node_count
     tags       = ["node-pool-minimal", local.cluster_name]
   }
 }

--- a/load-balancer.tf
+++ b/load-balancer.tf
@@ -1,5 +1,5 @@
 resource "digitalocean_loadbalancer" "ingress_load_balancer" {
-  name      = "${local.cluster_name}-lb"
+  name      = "${local.public_cluster_name}-lb"
   region    = var.region
   size      = "lb-small"
   algorithm = "round_robin"

--- a/locals.tf
+++ b/locals.tf
@@ -4,8 +4,9 @@ resource "random_string" "suffix" {
 }
 
 locals {
-  cluster_name = lower("jenkins-infra-doks-${random_string.suffix.result}")
-  public_cluster_name = lower("jenkins-infra-doks-public-${random_string.suffix.result}")
+  cluster_name                      = lower("jenkins-infra-doks-${random_string.suffix.result}")
+  public_cluster_name               = lower("jenkins-infra-doks-public-${random_string.suffix.result}")
+  public_cluster_minimal_node_count = 1
   # `doctl kubernetes options versions` doesn't return anything if the minor k8s version isn't supported anymore, note it can fail the build.
   doks_version           = data.digitalocean_kubernetes_versions.k8s.latest_version
   minimal_node_pool_size = "s-1vcpu-2gb" # Available sizes: `doctl compute size list`

--- a/locals.tf
+++ b/locals.tf
@@ -4,9 +4,8 @@ resource "random_string" "suffix" {
 }
 
 locals {
-  cluster_name                      = lower("jenkins-infra-doks-${random_string.suffix.result}")
-  public_cluster_name               = lower("jenkins-infra-doks-public-${random_string.suffix.result}")
-  public_cluster_minimal_node_count = 1
+  cluster_name        = lower("jenkins-infra-doks-${random_string.suffix.result}")
+  public_cluster_name = lower("jenkins-infra-doks-public-${random_string.suffix.result}")
   # `doctl kubernetes options versions` doesn't return anything if the minor k8s version isn't supported anymore, note it can fail the build.
   doks_version           = data.digitalocean_kubernetes_versions.k8s.latest_version
   minimal_node_pool_size = "s-1vcpu-2gb" # Available sizes: `doctl compute size list`

--- a/locals.tf
+++ b/locals.tf
@@ -5,6 +5,7 @@ resource "random_string" "suffix" {
 
 locals {
   cluster_name = lower("jenkins-infra-doks-${random_string.suffix.result}")
+  public_cluster_name = lower("jenkins-infra-doks-public-${random_string.suffix.result}")
   # `doctl kubernetes options versions` doesn't return anything if the minor k8s version isn't supported anymore, note it can fail the build.
   doks_version           = data.digitalocean_kubernetes_versions.k8s.latest_version
   minimal_node_pool_size = "s-1vcpu-2gb" # Available sizes: `doctl compute size list`


### PR DESCRIPTION
To be used for public services like the Artifact Caching Proxy, in order to avoid putting credentials on the cluster dedicated to ci.jenkins.io agents.

Fixes #66

Ref: https://github.com/jenkins-infra/helpdesk/issues/3114