### PR TITLE
fix: increase small node pool size to accommodate artifact-caching-proxy resources requests

### DIFF
--- a/doks-public-cluster.tf
+++ b/doks-public-cluster.tf
@@ -19,7 +19,7 @@ resource "digitalocean_kubernetes_cluster" "doks_public_cluster" {
   # Small node pool with autoscalling
   node_pool {
     name       = "small-node-pool"
-    size       = local.minimal_node_pool_size
+    size       = local.small_node_pool_size
     auto_scale = true
     min_nodes  = 1
     max_nodes  = var.autoscaled_node_pool_max_nodes

--- a/doks-public-cluster.tf
+++ b/doks-public-cluster.tf
@@ -16,13 +16,13 @@ resource "digitalocean_kubernetes_cluster" "doks_public_cluster" {
     day        = var.maintenance_policy_day
   }
 
-  # Small node pool with autoscalling
+  # One node pool with autoscalling
   node_pool {
-    name       = "small-node-pool"
-    size       = local.small_node_pool_size
+    name       = "public-node-pool"
+    size       = local.public_node_pool_size
     auto_scale = true
     min_nodes  = 1
     max_nodes  = var.autoscaled_node_pool_max_nodes
-    tags       = ["node-pool-small", local.public_cluster_name]
+    tags       = ["node-pool-publi", local.public_cluster_name]
   }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -9,4 +9,5 @@ locals {
   # `doctl kubernetes options versions` doesn't return anything if the minor k8s version isn't supported anymore, note it can fail the build.
   doks_version           = data.digitalocean_kubernetes_versions.k8s.latest_version
   minimal_node_pool_size = "s-1vcpu-2gb" # Available sizes: `doctl compute size list`
+  small_node_pool_size   = "s-2vcpu-4gb" # Available sizes: `doctl compute size list`
 }

--- a/locals.tf
+++ b/locals.tf
@@ -9,5 +9,5 @@ locals {
   # `doctl kubernetes options versions` doesn't return anything if the minor k8s version isn't supported anymore, note it can fail the build.
   doks_version           = data.digitalocean_kubernetes_versions.k8s.latest_version
   minimal_node_pool_size = "s-1vcpu-2gb" # Available sizes: `doctl compute size list`
-  small_node_pool_size   = "s-2vcpu-4gb" # Available sizes: `doctl compute size list`
+  public_node_pool_size  = "s-4vcpu-8gb" # Available sizes: `doctl compute size list`
 }


### PR DESCRIPTION
As the artifact-caching-proxy requests 2 vCPU and 4Go of memory, it couldn't be deployed on doks-public cluster as it hasn't enough resources per node:

> pod didn't trigger scale-up: 1 Insufficient cpu, 1 Insufficient memory

Ref: https://github.com/jenkins-infra/helpdesk/issues/2752