### PR TITLE
chore: update `doks` and `doks-public` clusters to Kubernetes 1.24

### DIFF
--- a/doks-cluster.tf
+++ b/doks-cluster.tf
@@ -1,5 +1,5 @@
 data "digitalocean_kubernetes_versions" "doks" {
-  version_prefix = "1.23."
+  version_prefix = "1.24."
 }
 
 resource "digitalocean_kubernetes_cluster" "doks_cluster" {

--- a/doks-public-cluster.tf
+++ b/doks-public-cluster.tf
@@ -1,5 +1,5 @@
 data "digitalocean_kubernetes_versions" "doks-public" {
-  version_prefix = "1.23."
+  version_prefix = "1.24."
 }
 
 resource "digitalocean_kubernetes_cluster" "doks_public_cluster" {


### PR DESCRIPTION
Ref: https://github.com/jenkins-infra/helpdesk/issues/3387