### PR TITLE
feat(doks) increase node pool capacity to 50 max 

### DIFF
--- a/doks-cluster.tf
+++ b/doks-cluster.tf
@@ -41,7 +41,7 @@ resource "digitalocean_kubernetes_node_pool" "autoscaled-pool" {
   size       = "c-16" # available sizes: `doctl compute size list`
   auto_scale = true
   min_nodes  = 1
-  max_nodes  = 10
+  max_nodes  = 50
   tags       = ["node-pool-autoscaled", local.cluster_name]
   lifecycle {
     ignore_changes = [


### PR DESCRIPTION
Depends on https://github.com/jenkins-infra/digitalocean/pull/102

This PR is related to https://github.com/jenkins-infra/helpdesk/issues/3391.
It increases the maximum capacity of the `doks` cluster to 50 nodes (to allow up to 150 pod agents)