### PR TITLE
feat(doks-public) limit autoscaled nodepool to max. 4 nodes + define maintenance window 2 hours later

### DIFF
--- a/doks-public-cluster.tf
+++ b/doks-public-cluster.tf
@@ -17,7 +17,7 @@ resource "digitalocean_kubernetes_cluster" "doks_public_cluster" {
   }
 
   maintenance_policy {
-    start_time = "04:00"
+    start_time = "06:00"
     day        = "sunday"
   }
 
@@ -27,7 +27,7 @@ resource "digitalocean_kubernetes_cluster" "doks_public_cluster" {
     size       = "s-4vcpu-8gb" # Available sizes: `doctl compute size list`
     auto_scale = true
     min_nodes  = 1
-    max_nodes  = 10
+    max_nodes  = 4
     tags       = ["public-node-pool", local.public_cluster_name]
   }
 }


### PR DESCRIPTION
Follows up #102 

- Setting up the maximum 4 nodes (upper limit). Twice the nominal limit (2 nodes).
- Maintenance window was at `04:00am` UTC for both clusters. Switched this cluster (`doks-public`) to `06:00am` UTC (2 hours later) to avoid an upgrade of the 2 clusters at the same time