### PR TITLE
feat(doks): increase node pool max nodes to 50

### DIFF
--- a/doks-cluster.tf
+++ b/doks-cluster.tf
@@ -41,7 +41,7 @@ resource "digitalocean_kubernetes_node_pool" "autoscaled-pool" {
   size       = "c-16" # available sizes: `doctl compute size list`
   auto_scale = true
   min_nodes  = 1
-  max_nodes  = 22
+  max_nodes  = 50
   tags       = ["node-pool-autoscaled", local.cluster_name]
   lifecycle {
     ignore_changes = [


### PR DESCRIPTION
As the droplets limit on DigitalOcean account has been increased to 100, we can now increase this cluster capacity to be the same as the AWS one.

Ref: https://github.com/jenkins-infra/jenkins-infra/pull/2679 & https://github.com/jenkins-infra/kubernetes-management/pull/3661