### PR TITLE
feat(doks,doks-public) enable HA for Kubernetes control-planes

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -42,3 +42,22 @@ provider "registry.terraform.io/hashicorp/local" {
     "zh:fa7ce69dde358e172bd719014ad637634bbdabc49363104f4fca759b4b73f2ce",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.5.1"
+  hashes = [
+    "h1:IL9mSatmwov+e0+++YX2V6uel+dV6bn+fC/cnGDK3Ck=",
+    "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
+    "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
+    "zh:4d2b219d09abf3b1bb4df93d399ed156cadd61f44ad3baf5cf2954df2fba0831",
+    "zh:6130bdde527587bbe2dcaa7150363e96dbc5250ea20154176d82bc69df5d4ce3",
+    "zh:6cc326cd4000f724d3086ee05587e7710f032f94fc9af35e96a386a1c6f2214f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b6d88e1d28cf2dfa24e9fdcc3efc77adcdc1c3c3b5c7ce503a423efbdd6de57b",
+    "zh:ba74c592622ecbcef9dc2a4d81ed321c4e44cddf7da799faa324da9bf52a22b2",
+    "zh:c7c5cde98fe4ef1143bd1b3ec5dc04baf0d4cc3ca2c5c7d40d17c0e9b2076865",
+    "zh:dac4bad52c940cd0dfc27893507c1e92393846b024c5a9db159a93c534a3da03",
+    "zh:de8febe2a2acd9ac454b844a4106ed295ae9520ef54dc8ed2faf29f12716b602",
+    "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
+  ]
+}

--- a/doks-cluster.tf
+++ b/doks-cluster.tf
@@ -9,6 +9,7 @@ resource "digitalocean_kubernetes_cluster" "doks_cluster" {
   version       = data.digitalocean_kubernetes_versions.doks.latest_version
   auto_upgrade  = true
   surge_upgrade = true
+  ha            = true
   tags          = ["managed-by:terraform"]
   lifecycle {
     ignore_changes = [

--- a/doks-public-cluster.tf
+++ b/doks-public-cluster.tf
@@ -9,6 +9,7 @@ resource "digitalocean_kubernetes_cluster" "doks_public_cluster" {
   version       = data.digitalocean_kubernetes_versions.doks-public.latest_version
   auto_upgrade  = true
   surge_upgrade = true
+  ha            = true
   tags          = ["managed-by:terraform"]
   lifecycle {
     ignore_changes = [


### PR DESCRIPTION
- HA upgrade done through the UI because https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/kubernetes_cluster#ha specifies that the cluster would deleted and re-created if done through Terraform
- Job is disabled on infra.ci
- A local terraform plan states: 

```
Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last "terraform apply":

  # digitalocean_kubernetes_cluster.doks_cluster has changed
  ~ resource "digitalocean_kubernetes_cluster" "doks_cluster" {
      ~ ha             = false -> true
        id             = "8f6e486f-86e9-45d0-a52b-d5554c70f4ec"
        name           = "jenkins-infra-doks-hkuxfyvb"
        tags           = [
            "managed-by:terraform",
        ]
      ~ updated_at     = "2023-06-21 13:24:07 +0000 UTC" -> "2023-06-22 15:22:50 +0000 UTC"
        # (13 unchanged attributes hidden)


        # (2 unchanged blocks hidden)
    }

  # digitalocean_kubernetes_cluster.doks_public_cluster has changed
  ~ resource "digitalocean_kubernetes_cluster" "doks_public_cluster" {
      ~ ha             = false -> true
        id             = "c2ac8f9f-55e0-44d7-9524-2848fd6e3747"
        name           = "jenkins-infra-doks-public-hkuxfyvb"
        tags           = [
            "managed-by:terraform",
        ]
      ~ updated_at     = "2023-06-21 13:06:27 +0000 UTC" -> "2023-06-22 15:24:17 +0000 UTC"
        # (12 unchanged attributes hidden)


        # (2 unchanged blocks hidden)
    }


Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes, the following plan may include actions to undo or respond to these changes.

──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

No changes. Your infrastructure matches the configuration.
```


we can merge and then re-enable the job