### PR TITLE
fix(updatecli): replace `title` by `name` in terraform-providers

### DIFF
--- a/updatecli/updatecli.d/terraform-providers.yaml
+++ b/updatecli/updatecli.d/terraform-providers.yaml
@@ -1,4 +1,4 @@
-title: "Bump Terraform plugins - not modules"
+name: "Bump Terraform plugins - not modules"
 
 scms:
   default:
@@ -31,7 +31,6 @@ actions:
   default:
     kind: github/pullrequest
     scmid: default
-    title: "Bump Terraform plugins - not modules"
     spec:
       labels:
         - dependencies


### PR DESCRIPTION
This PR aligns manifest syntax with other manifests like https://github.com/jenkins-infra/digitalocean/blob/main/updatecli/updatecli.d/hashicorp-tools.yml or (more exactly) https://github.com/jenkins-infra/azure/blob/main/updatecli/updatecli.d/terraform-providers.yaml

Note: no `title` in the `action` section is needed here as there is no variable in it, thus the `name` will be used as PR title.

Follow-up of https://github.com/jenkins-infra/digitalocean/pull/122#discussion_r1239756668