### PR TITLE
hotfix(archives.jenkins.io) correct volume name to only use lowercase alphanum

### DIFF
--- a/archives.jenkins.io.tf
+++ b/archives.jenkins.io.tf
@@ -5,7 +5,7 @@ resource "digitalocean_ssh_key" "archives_jenkins_io" {
 
 resource "digitalocean_volume" "archives_jenkins_io_data" {
   region                  = var.region
-  name                    = "archives.jenkins.io-data"
+  name                    = "archivesjenkinsiodata" # Only lowercase alphanum
   size                    = 700
   initial_filesystem_type = "ext4"
   description             = "Data disk for archives.jenkins.io"


### PR DESCRIPTION
Attempt to fix https://github.com/jenkins-infra/digitalocean/pull/157#issuecomment-1733925319