### PR TITLE
hotfix(archives.jenkins.io) user_data is not base64 encoded

### DIFF
--- a/archives.jenkins.io.tf
+++ b/archives.jenkins.io.tf
@@ -25,7 +25,7 @@ resource "digitalocean_droplet" "archives_jenkins_io" {
   ipv6        = true
   resize_disk = true
   ssh_keys    = [digitalocean_ssh_key.archives_jenkins_io.fingerprint]
-  user_data   = base64encode(templatefile("${path.root}/.shared-tools/terraform/cloudinit.tftpl", { hostname = "do.archives.jenkins.io" }))
+  user_data   = templatefile("${path.root}/.shared-tools/terraform/cloudinit.tftpl", { hostname = "do.archives.jenkins.io" })
 
 }
 


### PR DESCRIPTION
Found thanks to https://developer.hashicorp.com/terraform/tutorials/applications/digitalocean-provider