### PR TITLE
feat: manage DigitalOcean service DNS records

### DIFF
--- a/archives.jenkins.io.tf
+++ b/archives.jenkins.io.tf
@@ -25,7 +25,7 @@ resource "digitalocean_droplet" "archives_jenkins_io" {
   ipv6        = true
   resize_disk = true
   ssh_keys    = [digitalocean_ssh_key.archives_jenkins_io.fingerprint]
-  user_data   = templatefile("${path.root}/.shared-tools/terraform/cloudinit.tftpl", { hostname = "do.archives.jenkins.io" })
+  user_data   = templatefile("${path.root}/.shared-tools/terraform/cloudinit.tftpl", { hostname = "archives.do.jenkins.io" })
 
 }
 

--- a/dns.tf
+++ b/dns.tf
@@ -1,0 +1,26 @@
+# Child DNS Zone delegated from Azure
+# https://docs.digitalocean.com/products/networking/dns/getting-started/dns-registrars/
+resource "digitalocean_domain" "do_jenkins_io" {
+  name = "do.jenkins.io"
+}
+
+resource "digitalocean_record" "repo_ipv4" {
+  domain = digitalocean_domain.do_jenkins_io.id
+  type   = "A"
+  name   = "repo"
+  value  = data.digitalocean_loadbalancer.doks_public.ip
+}
+
+resource "digitalocean_record" "archives_ipv4" {
+  domain = digitalocean_domain.do_jenkins_io.id
+  type   = "A"
+  name   = "archives"
+  value  = digitalocean_droplet.archives_jenkins_io.ipv4_address
+}
+
+resource "digitalocean_record" "archives_ipv6" {
+  domain = digitalocean_domain.do_jenkins_io.id
+  type   = "AAAA"
+  name   = "archives"
+  value  = digitalocean_droplet.archives_jenkins_io.ipv6_address
+}

--- a/doks-public-cluster.tf
+++ b/doks-public-cluster.tf
@@ -68,6 +68,10 @@ output "kubeconfig_doks_public" {
   value     = module.doks_public_admin_sa.kubeconfig
 }
 
+data "digitalocean_loadbalancer" "doks_public" {
+  name = "a04ff19a8410b4ac5a2b5c383b23a8b2"
+}
+
 output "doks_public_public_ipv4_address" {
-  value = digitalocean_kubernetes_cluster.doks_public_cluster.ipv4_address
+  value = data.digitalocean_loadbalancer.doks_public.ip
 }


### PR DESCRIPTION
As suggested by @lemeurherve , let's manage the DNS records of services hosted in DO through a DNS child zone.

Related to https://github.com/jenkins-infra/helpdesk/issues/3760

This PR is the first step: it creates the DNS child zone with records for:

- `archives.do` 
  - Both IPv4 (`A` record) and IPv6 (`AAAA` record)
  - Rename the newly created VM from `do.archives.jenkins.io` to `archives.do.jenkins.io` to follow DNS records => re-create the VM but no problem it is still being evaluated
- `repo.do`
  - Added a data source to retrieve the LB's IPv4 (no IPv6), ss the LB must be managed by the `doks-public` cluster, and only by it
  - Updated the `doks-public` output to use the LB data source (and avoid having an empty IP)
  - Ipv4 only (`A` record).

⚠️ This won't change the current DNS records because a delegation is required from Azure's `jenkins.io` DNS zone through `NS` records pointing to Digital Ocean Nameservers. Ref. https://docs.digitalocean.com/products/networking/dns/getting-started/dns-registrars/.

DigitalOcean provides 3 static nameservers: `ns1.digitalocean.com`, `ns2.digitalocean.com` and `ns3.digitalocean.com` so easier to manage than Cloudflare's for instance.

We can test this PR, once merged and deployed without error, with the following commands:

```
# Should respond 157.245.23.55
dig A @ns1.digitalocean.com repo.do.jenkins.io
# Should respond IPv4 of new VM
dig A @ns3.digitalocean.com archives.do.jenkins.io
# Should respond IPv6 of new VM
dig AAAA @ns2.digitalocean.com archives.do.jenkins.io
```
