### PR TITLE
chore: reuse shared data from the new 'jenkins-infra' common module

### DIFF
--- a/archives.jenkins.io.tf
+++ b/archives.jenkins.io.tf
@@ -40,9 +40,9 @@ resource "digitalocean_firewall" "archives_jenkins_io" {
     port_range = "22"
 
     source_addresses = flatten(concat(
-      [for key, value in module.jenkins_infra.admin_public_ips : value],
-      module.jenkins_infra.outbound_ips["pkg.jenkins.io"],
-      module.jenkins_infra.outbound_ips["trusted.ci.jenkins.io"],
+      [for key, value in module.jenkins_infra_shared_data.admin_public_ips : value],
+      module.jenkins_infra_shared_data.outbound_ips["pkg.jenkins.io"],
+      module.jenkins_infra_shared_data.outbound_ips["trusted.ci.jenkins.io"],
     ))
   }
 
@@ -94,16 +94,16 @@ resource "digitalocean_firewall" "archives_jenkins_io" {
     protocol   = "tcp"
     port_range = "873"
     destination_addresses = flatten(concat(
-      module.jenkins_infra.external_service_ips["ftp-osl.osuosl.org"],
-      module.jenkins_infra.outbound_ips["pkg.jenkins.io"],
+      module.jenkins_infra_shared_data.external_service_ips["ftp-osl.osuosl.org"],
+      module.jenkins_infra_shared_data.outbound_ips["pkg.jenkins.io"],
     ))
   }
   outbound_rule {
     protocol   = "tcp"
     port_range = "22"
     destination_addresses = flatten(concat(
-      module.jenkins_infra.external_service_ips["ftp-osl.osuosl.org"],
-      module.jenkins_infra.outbound_ips["pkg.jenkins.io"],
+      module.jenkins_infra_shared_data.external_service_ips["ftp-osl.osuosl.org"],
+      module.jenkins_infra_shared_data.outbound_ips["pkg.jenkins.io"],
     ))
   }
 }

--- a/archives.jenkins.io.tf
+++ b/archives.jenkins.io.tf
@@ -39,16 +39,11 @@ resource "digitalocean_firewall" "archives_jenkins_io" {
     protocol   = "tcp"
     port_range = "22"
 
-    # TODO: implement a common way to share admin IPs through terraform projects
-    source_addresses = [
-      "109.88.234.158/32",  # dduportal
-      "176.185.227.180/32", # hlemeur
-      "162.142.59.220/32",  # mwaite
-      "82.64.5.129/32",     # smerle33
-      "129.146.98.132/32",  # Oracle's VM archives.jenkins.io (for data migration)
-      "52.202.51.185/32",   # pkg.jenkins.io
-      "104.209.128.236/32", # trusted.ci.jenkins.io
-    ]
+    source_addresses = flatten(concat(
+      [for key, value in module.jenkins_infra.admin_public_ips : value],
+      module.jenkins_infra.outbound_ips["pkg.jenkins.io"],
+      module.jenkins_infra.outbound_ips["trusted.ci.jenkins.io"],
+    ))
   }
 
   inbound_rule {
@@ -94,15 +89,21 @@ resource "digitalocean_firewall" "archives_jenkins_io" {
     destination_addresses = ["20.12.27.65/32"]
   }
 
-  ## Allow rsync protocol to OSUOSL and updates.jenkins.io
+  ## Allow rsyncing to OSUOSL and pkg.jenkins.io
   outbound_rule {
-    protocol              = "tcp"
-    port_range            = "873"
-    destination_addresses = ["0.0.0.0/0", "::/0"]
-    #destination_addresses = [
-    #  "140.211.166.134/32",     # ftp-osl.osuosl.org
-    #  "2605:bc80:3010::134/32", # ftp-osl.osuosl.org
-    #  "52.202.51.185/32",       # updates.jenkins.io
-    #]
+    protocol   = "tcp"
+    port_range = "873"
+    destination_addresses = flatten(concat(
+      module.jenkins_infra.external_service_ips["ftp-osl.osuosl.org"],
+      module.jenkins_infra.outbound_ips["pkg.jenkins.io"],
+    ))
+  }
+  outbound_rule {
+    protocol   = "tcp"
+    port_range = "22"
+    destination_addresses = flatten(concat(
+      module.jenkins_infra.external_service_ips["ftp-osl.osuosl.org"],
+      module.jenkins_infra.outbound_ips["pkg.jenkins.io"],
+    ))
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,3 @@
+module "jenkins_infra" {
+  source = "./.shared-tools/terraform/modules/jenkins-infra-shared-data"
+}

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,3 @@
-module "jenkins_infra" {
+module "jenkins_infra_shared_data" {
   source = "./.shared-tools/terraform/modules/jenkins-infra-shared-data"
 }


### PR DESCRIPTION
This PR is a first try at sharing a set common values across our terraform projects.

A new [data-only Terraform module](https://developer.hashicorp.com/terraform/language/modules/develop/composition#data-only-modules) has been added in the jenkins-infra/shared-tools to hold the shared values: https://github.com/jenkins-infra/shared-tools/commit/36589078701232007dbdf8b5034fd93901d072c3.

The following changes are introduced to the archives.jenkins.io VM:

- Use "IP" instead of CIDR mask for firewall rules
- Add outbound SSH to allow rsync through SSH protocol (instead of rsync) to OSUOSL or pkg VM
- Restrict rsync to only OSUOSL or pkg VM

💡 Notes:

- This module, for now, only specify a set of outputs providing the shared data to projects. It may provide data sources (Azure DNS zones or network ids?) in the future if need be for instance.
- The choice of mixing IPv6 and IPv4 in the string arrays is because most of the usages requires both. If we need to filter by type, we can use `can(cidrnetmask(...)` and `!can(cidrnetmask(...))` (ref. https://developer.hashicorp.com/terraform/language/functions/cidrnetmask)
- The idea is that, in the near future, each terraform project should be able to update the values of the module when needed (case of public or outbound IPs of our services) or a human (admin IPs).





