### PR TITLE
feat(doks) bump Kubernetes version from 1.25.to 1.26

### DIFF
--- a/doks-cluster.tf
+++ b/doks-cluster.tf
@@ -1,5 +1,5 @@
 data "digitalocean_kubernetes_versions" "doks" {
-  version_prefix = "1.25."
+  version_prefix = "1.26."
 }
 
 resource "digitalocean_kubernetes_cluster" "doks_cluster" {


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3683