### PR TITLE
feat(doks-public) bump Kubernetes version from 1.25.to 1.26

### DIFF
--- a/doks-public-cluster.tf
+++ b/doks-public-cluster.tf
@@ -1,5 +1,5 @@
 data "digitalocean_kubernetes_versions" "doks-public" {
-  version_prefix = "1.25."
+  version_prefix = "1.26."
 }
 
 resource "digitalocean_kubernetes_cluster" "doks_public_cluster" {


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3683

Self-merging with a manually applied upgrade