### PR TITLE
chore: use terraform `1.6` instead of `1.1`

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,3 +1,5 @@
+@Library('pipeline-library@pull/826/head') _
+
 parallel(
   failFast: false,
   'terraform': {

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.1, <1.2"
+  required_version = ">= 1.6, <1.7"
   required_providers {
     digitalocean = {
       source = "digitalocean/digitalocean"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/3823