### PR TITLE
chore(`doks` / `doks public`) remove datasource kube hacks around lifecycle

### DIFF
--- a/doks-cluster.tf
+++ b/doks-cluster.tf
@@ -11,12 +11,6 @@ resource "digitalocean_kubernetes_cluster" "doks_cluster" {
   surge_upgrade = true
   ha            = true
   tags          = ["managed-by:terraform"]
-  lifecycle {
-    ignore_changes = [
-      updated_at,
-      version,
-    ]
-  }
 
   maintenance_policy {
     start_time = "04:00"
@@ -45,13 +39,6 @@ resource "digitalocean_kubernetes_node_pool" "autoscaled-pool" {
   min_nodes  = 1
   max_nodes  = 50
   tags       = ["node-pool-autoscaled", local.cluster_name]
-  lifecycle {
-    ignore_changes = [
-      node_count,
-      actual_node_count,
-      nodes,
-    ]
-  }
 }
 
 # Data source required to configure the kubernetes provider as per https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/kubernetes_cluster#kubernetes-terraform-provider-example

--- a/doks-public-cluster.tf
+++ b/doks-public-cluster.tf
@@ -34,20 +34,20 @@ resource "digitalocean_kubernetes_cluster" "doks_public_cluster" {
 }
 
 # Data source required to configure the kubernetes provider as per https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/kubernetes_cluster#kubernetes-terraform-provider-example
-data "digitalocean_kubernetes_cluster" "doks_public" {
-  name       = local.public_cluster_name
-  depends_on = [digitalocean_kubernetes_cluster.doks_public_cluster]
-}
+# data "digitalocean_kubernetes_cluster" "doks_public" {
+#   name       = local.public_cluster_name
+#   depends_on = [digitalocean_kubernetes_cluster.doks_public_cluster]
+# }
 provider "kubernetes" {
   alias                  = "doks_public"
-  host                   = data.digitalocean_kubernetes_cluster.doks_public.kube_config.0.host
-  cluster_ca_certificate = base64decode(data.digitalocean_kubernetes_cluster.doks_public.kube_config.0.cluster_ca_certificate)
+  host                   = digitalocean_kubernetes_cluster.doks_public_cluster.kube_config.0.host
+  cluster_ca_certificate = base64decode(digitalocean_kubernetes_cluster.doks_public_cluster.kube_config.0.cluster_ca_certificate)
   # Bootstrap requires to use the DigitalOcean API user as no service account or technical user are created in the cluster
   exec {
     api_version = "client.authentication.k8s.io/v1beta1"
     command     = "doctl"
     args = ["kubernetes", "cluster", "kubeconfig", "exec-credential",
-    "--version=v1beta1", data.digitalocean_kubernetes_cluster.doks_public.id]
+    "--version=v1beta1", digitalocean_kubernetes_cluster.doks_public_cluster.id]
   }
 }
 
@@ -58,8 +58,8 @@ module "doks_public_admin_sa" {
   }
   source                     = "./.shared-tools/terraform/modules/kubernetes-admin-sa"
   cluster_name               = local.public_cluster_name
-  cluster_hostname           = data.digitalocean_kubernetes_cluster.doks_public.kube_config.0.host
-  cluster_ca_certificate_b64 = data.digitalocean_kubernetes_cluster.doks_public.kube_config.0.cluster_ca_certificate
+  cluster_hostname           = digitalocean_kubernetes_cluster.doks_public_cluster.kube_config.0.host
+  cluster_ca_certificate_b64 = digitalocean_kubernetes_cluster.doks_public_cluster.kube_config.0.cluster_ca_certificate
 }
 
 output "kubeconfig_doks_public" {

--- a/doks-public-cluster.tf
+++ b/doks-public-cluster.tf
@@ -14,7 +14,6 @@ resource "digitalocean_kubernetes_cluster" "doks_public_cluster" {
   lifecycle {
     ignore_changes = [
       updated_at,
-      version,
     ]
   }
 

--- a/doks-public-cluster.tf
+++ b/doks-public-cluster.tf
@@ -33,11 +33,6 @@ resource "digitalocean_kubernetes_cluster" "doks_public_cluster" {
   }
 }
 
-# Data source required to configure the kubernetes provider as per https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/kubernetes_cluster#kubernetes-terraform-provider-example
-# data "digitalocean_kubernetes_cluster" "doks_public" {
-#   name       = local.public_cluster_name
-#   depends_on = [digitalocean_kubernetes_cluster.doks_public_cluster]
-# }
 provider "kubernetes" {
   alias                  = "doks_public"
   host                   = digitalocean_kubernetes_cluster.doks_public_cluster.kube_config.0.host

--- a/doks-public-cluster.tf
+++ b/doks-public-cluster.tf
@@ -11,11 +11,6 @@ resource "digitalocean_kubernetes_cluster" "doks_public_cluster" {
   surge_upgrade = true
   ha            = true
   tags          = ["managed-by:terraform"]
-  lifecycle {
-    ignore_changes = [
-      updated_at,
-    ]
-  }
 
   maintenance_policy {
     start_time = "06:00"


### PR DESCRIPTION
This PR comes from the initial work on https://github.com/jenkins-infra/helpdesk/issues/3948 (see PRs #179 #180 and #182 ).

It introduces the following changes:

- chore: Bump shared tools to latest version
- Cherry pick changes by @smerle33 in #179 to remove the data source used to configure the 2 instances of the kubernetes terraform provider used to create resources in the cluster `doks` and `doks-public`
  - This change is possible as we are using Terraform 1.6 which solved the lifecycle problems we had with DigitalOcean provider and the 1.1.x version of Terraform
- chore: silence warnings related to `lifecycle` which is not required anymore

=> As #179 and #180 showed, and since our clusters are now up to date with 1.26.x line, this PR should NOT introducer any change to the DigitalOcean infrastructure.

**However** we might see the build to fail when a new patch version will be available: we'll have to prepare a separate PR with `updatecli` to let us know there is a new cluster version available.