### PR TITLE
chore(doks) remove data source hack used to setup kubernetes provider

### DIFF
--- a/doks-cluster.tf
+++ b/doks-cluster.tf
@@ -41,21 +41,16 @@ resource "digitalocean_kubernetes_node_pool" "autoscaled-pool" {
   tags       = ["node-pool-autoscaled", local.cluster_name]
 }
 
-# Data source required to configure the kubernetes provider as per https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/kubernetes_cluster#kubernetes-terraform-provider-example
-data "digitalocean_kubernetes_cluster" "doks" {
-  name       = local.cluster_name
-  depends_on = [digitalocean_kubernetes_cluster.doks_cluster]
-}
 provider "kubernetes" {
   alias                  = "doks"
-  host                   = data.digitalocean_kubernetes_cluster.doks.kube_config.0.host
-  cluster_ca_certificate = base64decode(data.digitalocean_kubernetes_cluster.doks.kube_config.0.cluster_ca_certificate)
+  host                   = digitalocean_kubernetes_cluster.doks_cluster.kube_config.0.host
+  cluster_ca_certificate = base64decode(digitalocean_kubernetes_cluster.doks_cluster.kube_config.0.cluster_ca_certificate)
   # Bootstrap requires to use the DigitalOcean API user as no service account or technical user are created in the cluster
   exec {
     api_version = "client.authentication.k8s.io/v1beta1"
     command     = "doctl"
     args = ["kubernetes", "cluster", "kubeconfig", "exec-credential",
-    "--version=v1beta1", data.digitalocean_kubernetes_cluster.doks.id]
+    "--version=v1beta1", digitalocean_kubernetes_cluster.doks_cluster.id]
   }
 }
 
@@ -66,8 +61,8 @@ module "doks_admin_sa" {
   }
   source                     = "./.shared-tools/terraform/modules/kubernetes-admin-sa"
   cluster_name               = local.cluster_name
-  cluster_hostname           = data.digitalocean_kubernetes_cluster.doks.kube_config.0.host
-  cluster_ca_certificate_b64 = data.digitalocean_kubernetes_cluster.doks.kube_config.0.cluster_ca_certificate
+  cluster_hostname           = digitalocean_kubernetes_cluster.doks_cluster.kube_config.0.host
+  cluster_ca_certificate_b64 = digitalocean_kubernetes_cluster.doks_cluster.kube_config.0.cluster_ca_certificate
 }
 
 output "kubeconfig_doks" {


### PR DESCRIPTION
Fixup of #183

Same expectations: we forgot to apply the change to `doks` itself.

Same expectation: no changes should be done in the plan.