### PR TITLE
feat(doks-public) bump Kubernetes version from 1.26.to 1.27 digitalocean (second round)

### DIFF
--- a/doks-public-cluster.tf
+++ b/doks-public-cluster.tf
@@ -1,5 +1,5 @@
 data "digitalocean_kubernetes_versions" "doks-public" {
-  version_prefix = "1.26."
+  version_prefix = "1.27."
 }
 
 resource "digitalocean_kubernetes_cluster" "doks_public_cluster" {


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/3948#issuecomment-1948211120

```
Terraform will perform the following actions:

  # digitalocean_kubernetes_cluster.doks_public_cluster will be updated in-place
  ~ resource "digitalocean_kubernetes_cluster" "doks_public_cluster" {
        id                               = "<redacted>"
        name                             = "jenkins-infra-doks-public-hkuxfyvb"
        tags                             = [
            "managed-by:terraform",
        ]
      ~ version                          = "1.26.13-do.0" -> "1.27.10-do.0"
        # (15 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```
