### PR TITLE
feat(archives.jenkins.io) upsize archives.jenkins.io to ensure good performances when fall-backing in

### DIFF
--- a/archives.jenkins.io.tf
+++ b/archives.jenkins.io.tf
@@ -20,7 +20,7 @@ resource "digitalocean_droplet" "archives_jenkins_io" {
   image       = "ubuntu-22-04-x64"
   name        = "archives.jenkins.io"
   region      = var.region
-  size        = "s-2vcpu-2gb"
+  size        = "s-4vcpu-8gb"
   monitoring  = true
   ipv6        = true
   resize_disk = true


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4330

Applied manually already