### PR TITLE
fix(archives.jio) correct cloudinit call

### DIFF
--- a/archives.jenkins.io-cloudinit.tftpl
+++ b/archives.jenkins.io-cloudinit.tftpl
@@ -1,0 +1,26 @@
+#cloud-config
+write_files:
+  # Configuration file for puppet agent on this VM (${hostname})
+  # Not directly at the destination path as it would get the the puppet package installation stuck (asking to override)
+  # Also, when writing files, do not use /tmp dir as it races with systemd-tmp. Use /run/<somedir> instead (as per. : https://cloudinit.readthedocs.io/en/latest/topics/modules.html#runcmd)
+  - path: /run/puppetinstall/puppet.conf
+    owner: root:root
+    permissions: '0640'
+    content: |
+      [main]
+      server = puppet.jenkins.io
+      [agent]
+      certname = ${hostname}
+runcmd:
+  - [ mkdir, -p, /run/puppetinstall ]
+  - [ apt-get, update, --yes, --quiet ]
+  - [ apt-get, install, --yes, --quiet, --no-install-recommends, bash-completion, cron, htop, iotop, locales, vim, wget ]
+  - [ wget, "https://apt.puppetlabs.com/puppet6-release-focal.deb", -O, /run/puppetinstall/puppet6-release-focal.deb ]
+  - [ locale-gen, en_US.UTF-8 ]
+  - [ dpkg, -i, /run/puppetinstall/puppet6-release-focal.deb ]
+  - [ apt-get, update, --yes, --quiet ]
+  - [ apt-get, install, "puppet-agent=6.*", --yes, --quiet, --no-install-recommends ]
+  # see above comment in the "write_files" section
+  - [ mv, /run/puppetinstall/puppet.conf, /etc/puppetlabs/puppet/puppet.conf]
+  - [ systemctl, enable, puppet ]
+  - [ systemctl, start, puppet ]

--- a/archives.jenkins.io.tf
+++ b/archives.jenkins.io.tf
@@ -25,7 +25,10 @@ resource "digitalocean_droplet" "archives_jenkins_io" {
   ipv6        = true
   resize_disk = true
   ssh_keys    = [digitalocean_ssh_key.archives_jenkins_io.fingerprint]
-  user_data   = templatefile("${path.root}/.shared-tools/terraform/cloudinit.tftpl", { hostname = "archives.do.jenkins.io" })
+  user_data = templatefile("${path.root}/.shared-tools/terraform/cloudinit.tftpl", {
+    hostname       = "archives.do.jenkins.io",
+    admin_username = "",
+  })
 }
 
 ## Allow accessing the internet in HTTP/HTTPS/DNS and allow incoming HTTP/HTTP from anywhere (public service)

--- a/archives.jenkins.io.tf
+++ b/archives.jenkins.io.tf
@@ -25,10 +25,7 @@ resource "digitalocean_droplet" "archives_jenkins_io" {
   ipv6        = true
   resize_disk = true
   ssh_keys    = [digitalocean_ssh_key.archives_jenkins_io.fingerprint]
-  user_data = templatefile("${path.root}/.shared-tools/terraform/cloudinit.tftpl", {
-    hostname       = "archives.do.jenkins.io",
-    admin_username = "",
-  })
+  user_data   = templatefile("${path.root}/archives.jenkins.io-cloudinit.tftpl", { hostname = "archives.do.jenkins.io" })
 }
 
 ## Allow accessing the internet in HTTP/HTTPS/DNS and allow incoming HTTP/HTTP from anywhere (public service)


### PR DESCRIPTION
This PR updates the cloudinit.

Please note: in DigitalOcean, the default Administrator user is `root`. As such, we pass the empty string to avoid trying to change `root` ID 😅