### PR TITLE
chore(archives.jio): split firewall in 2 subsets

### DIFF
--- a/archives.jenkins.io.tf
+++ b/archives.jenkins.io.tf
@@ -1,5 +1,6 @@
 resource "digitalocean_ssh_key" "archives_jenkins_io" {
-  name       = "Administrator Public SSH Key for archives.jenkins.io"
+  name = "Administrator Public SSH Key for archives.jenkins.io"
+  # the private key is stored within sops: config/archives.jenkins.io/id_archives_do_jenkins_io
   public_key = file("ssh/id_archives_jenkins_io.pub")
 }
 
@@ -17,6 +18,7 @@ resource "digitalocean_volume_attachment" "archives_jenkins_io_data" {
 }
 
 resource "digitalocean_droplet" "archives_jenkins_io" {
+  # default username is root. TODO change it with cloudinit
   image       = "ubuntu-22-04-x64"
   name        = "archives.jenkins.io"
   region      = var.region
@@ -26,86 +28,4 @@ resource "digitalocean_droplet" "archives_jenkins_io" {
   resize_disk = true
   ssh_keys    = [digitalocean_ssh_key.archives_jenkins_io.fingerprint]
   user_data   = templatefile("${path.root}/archives.jenkins.io-cloudinit.tftpl", { hostname = "archives.do.jenkins.io" })
-}
-
-## Allow accessing the internet in HTTP/HTTPS/DNS and allow incoming HTTP/HTTP from anywhere (public service)
-#trivy:ignore:AVD-DIG-0001 trivy:ignore:AVD-DIG-0003
-resource "digitalocean_firewall" "archives_jenkins_io" {
-  name = "archives.jenkins.io"
-
-  droplet_ids = [digitalocean_droplet.archives_jenkins_io.id]
-
-  inbound_rule {
-    protocol   = "tcp"
-    port_range = "22"
-
-    source_addresses = flatten(concat(
-      module.jenkins_infra_shared_data.outbound_ips["pkg.jenkins.io"],                    # Data sync script from the `pkg` VM
-      module.jenkins_infra_shared_data.outbound_ips["trusted.ci.jenkins.io"],             # permanent agent of update_center2
-      module.jenkins_infra_shared_data.outbound_ips["trusted.sponsorship.ci.jenkins.io"], # ephemeral agents for crawler
-      module.jenkins_infra_shared_data.outbound_ips["privatek8s.jenkins.io"],             # Terraform management + VPN VM
-      module.jenkins_infra_shared_data.outbound_ips["private.vpn.jenkins.io"],            # connections routed through the VPN
-    ))
-  }
-
-  inbound_rule {
-    protocol         = "tcp"
-    port_range       = "80"
-    source_addresses = ["0.0.0.0/0", "::/0"]
-  }
-
-  inbound_rule {
-    protocol         = "tcp"
-    port_range       = "443"
-    source_addresses = ["0.0.0.0/0", "::/0"]
-  }
-
-  outbound_rule {
-    protocol              = "tcp"
-    port_range            = "53"
-    destination_addresses = ["0.0.0.0/0", "::/0"]
-  }
-
-  outbound_rule {
-    protocol              = "udp"
-    port_range            = "53"
-    destination_addresses = ["0.0.0.0/0", "::/0"]
-  }
-
-  outbound_rule {
-    protocol              = "tcp"
-    port_range            = "80"
-    destination_addresses = ["0.0.0.0/0", "::/0"]
-  }
-
-  outbound_rule {
-    protocol              = "tcp"
-    port_range            = "443"
-    destination_addresses = ["0.0.0.0/0", "::/0"]
-  }
-
-  ## Allow puppet protocol to puppet.jenkins.io
-  outbound_rule {
-    protocol              = "tcp"
-    port_range            = "8140"
-    destination_addresses = ["20.12.27.65/32"]
-  }
-
-  ## Allow rsyncing to OSUOSL and pkg.jenkins.io
-  outbound_rule {
-    protocol   = "tcp"
-    port_range = "873"
-    destination_addresses = flatten(concat(
-      module.jenkins_infra_shared_data.external_service_ips["ftp-osl.osuosl.org"],
-      module.jenkins_infra_shared_data.outbound_ips["pkg.jenkins.io"],
-    ))
-  }
-  outbound_rule {
-    protocol   = "tcp"
-    port_range = "22"
-    destination_addresses = flatten(concat(
-      module.jenkins_infra_shared_data.external_service_ips["ftp-osl.osuosl.org"],
-      module.jenkins_infra_shared_data.outbound_ips["pkg.jenkins.io"],
-    ))
-  }
 }

--- a/firewalls.tf
+++ b/firewalls.tf
@@ -7,11 +7,7 @@ resource "digitalocean_firewall" "default" {
     port_range = "22"
 
     source_addresses = flatten(concat(
-      module.jenkins_infra_shared_data.outbound_ips["pkg.jenkins.io"],                    # Data sync script from the `pkg` VM
-      module.jenkins_infra_shared_data.outbound_ips["trusted.ci.jenkins.io"],             # permanent agent of update_center2
-      module.jenkins_infra_shared_data.outbound_ips["trusted.sponsorship.ci.jenkins.io"], # ephemeral agents for crawler
-      module.jenkins_infra_shared_data.outbound_ips["privatek8s.jenkins.io"],             # Terraform management + VPN VM
-      module.jenkins_infra_shared_data.outbound_ips["private.vpn.jenkins.io"],            # connections routed through the VPN
+      module.jenkins_infra_shared_data.outbound_ips["private.vpn.jenkins.io"], # connections routed through the VPN
     ))
   }
 
@@ -51,18 +47,16 @@ resource "digitalocean_firewall" "archives" {
   name        = "archives"
   droplet_ids = [digitalocean_droplet.archives_jenkins_io.id]
 
-  # open http to serve pages
   inbound_rule {
-    protocol         = "tcp"
-    port_range       = "80"
-    source_addresses = ["0.0.0.0/0", "::/0"]
-  }
+    protocol   = "tcp"
+    port_range = "22"
 
-  # open https to serve pages
-  inbound_rule {
-    protocol         = "tcp"
-    port_range       = "443"
-    source_addresses = ["0.0.0.0/0", "::/0"]
+    source_addresses = flatten(concat(
+      module.jenkins_infra_shared_data.outbound_ips["pkg.jenkins.io"],                    # Data sync script from the `pkg` VM
+      module.jenkins_infra_shared_data.outbound_ips["trusted.ci.jenkins.io"],             # permanent agent of update_center2
+      module.jenkins_infra_shared_data.outbound_ips["trusted.sponsorship.ci.jenkins.io"], # ephemeral agents for crawler
+      module.jenkins_infra_shared_data.outbound_ips["privatek8s.jenkins.io"],             # Terraform management + VPN VM
+    ))
   }
 
   ## Allow rsyncing to OSUOSL and pkg.jenkins.io
@@ -82,4 +76,24 @@ resource "digitalocean_firewall" "archives" {
       module.jenkins_infra_shared_data.outbound_ips["pkg.jenkins.io"],
     ))
   }
+}
+
+resource "digitalocean_firewall" "web" {
+  name        = "web"
+  droplet_ids = [digitalocean_droplet.archives_jenkins_io.id]
+
+  # open http to serve pages
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "80"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  # open https to serve pages
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "443"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
 }

--- a/firewalls.tf
+++ b/firewalls.tf
@@ -1,0 +1,85 @@
+resource "digitalocean_firewall" "default" {
+  name        = "default"
+  droplet_ids = [digitalocean_droplet.archives_jenkins_io.id]
+
+  inbound_rule {
+    protocol   = "tcp"
+    port_range = "22"
+
+    source_addresses = flatten(concat(
+      module.jenkins_infra_shared_data.outbound_ips["pkg.jenkins.io"],                    # Data sync script from the `pkg` VM
+      module.jenkins_infra_shared_data.outbound_ips["trusted.ci.jenkins.io"],             # permanent agent of update_center2
+      module.jenkins_infra_shared_data.outbound_ips["trusted.sponsorship.ci.jenkins.io"], # ephemeral agents for crawler
+      module.jenkins_infra_shared_data.outbound_ips["privatek8s.jenkins.io"],             # Terraform management + VPN VM
+      module.jenkins_infra_shared_data.outbound_ips["private.vpn.jenkins.io"],            # connections routed through the VPN
+    ))
+  }
+
+  outbound_rule {
+    protocol              = "tcp"
+    port_range            = "53"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "udp"
+    port_range            = "53"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "tcp"
+    port_range            = "80"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "tcp"
+    port_range            = "443"
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  ## Allow puppet protocol to puppet.jenkins.io
+  outbound_rule {
+    protocol              = "tcp"
+    port_range            = "8140"
+    destination_addresses = ["20.12.27.65/32"] # todo updatecli this ip
+  }
+}
+
+resource "digitalocean_firewall" "archives" {
+  name        = "archives"
+  droplet_ids = [digitalocean_droplet.archives_jenkins_io.id]
+
+  # open http to serve pages
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "80"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  # open https to serve pages
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "443"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  ## Allow rsyncing to OSUOSL and pkg.jenkins.io
+  outbound_rule {
+    protocol   = "tcp"
+    port_range = "873"
+    destination_addresses = flatten(concat(
+      module.jenkins_infra_shared_data.external_service_ips["ftp-osl.osuosl.org"],
+      module.jenkins_infra_shared_data.outbound_ips["pkg.jenkins.io"],
+    ))
+  }
+  outbound_rule {
+    protocol   = "tcp"
+    port_range = "22"
+    destination_addresses = flatten(concat(
+      module.jenkins_infra_shared_data.external_service_ips["ftp-osl.osuosl.org"],
+      module.jenkins_infra_shared_data.outbound_ips["pkg.jenkins.io"],
+    ))
+  }
+}


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4621
we need to separate the firewalls and to split them in order to use them for multiple droplets