### PR TITLE
fix(puppet): rename machine name to comply DO rules

### DIFF
--- a/puppet.do.jenkins.io.tf
+++ b/puppet.do.jenkins.io.tf
@@ -5,7 +5,7 @@ resource "digitalocean_ssh_key" "puppet_do_jenkins_io" {
 
 resource "digitalocean_droplet" "puppet_do_jenkins_io" {
   image       = "ubuntu-20-04-x64"
-  name        = "puppet_do.jenkins.io"
+  name        = "puppet.do.jenkins.io"
   region      = var.region
   size        = "s-2vcpu-8gb-amd" # Basic AMD 	s-2vcpu-8gb-amd	8 GB 	2 	100 GB 	5 TB 	$42 	$0.0625 https://slugs.do-api.dev/
   monitoring  = true


### PR DESCRIPTION
for https://github.com/jenkins-infra/helpdesk/issues/4621 and as per https://github.com/jenkins-infra/digitalocean/pull/223#issuecomment-2776383824
renaming the puppet machine to avoid `_`