### PR TITLE
chore: export report and cleanup provider setup

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -26,3 +26,22 @@ provider "registry.terraform.io/digitalocean/digitalocean" {
     "zh:ec3f6eb696309a4dc2a066fdf8a794f136f3cd9810a7ad98859cf7b0ce39cf2e",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.5.3"
+  hashes = [
+    "h1:MCzg+hs1/ZQ32u56VzJMWP9ONRQPAAqAjuHuzbyshvI=",
+    "zh:284d4b5b572eacd456e605e94372f740f6de27b71b4e1fd49b63745d8ecd4927",
+    "zh:40d9dfc9c549e406b5aab73c023aa485633c1b6b730c933d7bcc2fa67fd1ae6e",
+    "zh:6243509bb208656eb9dc17d3c525c89acdd27f08def427a0dce22d5db90a4c8b",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:885d85869f927853b6fe330e235cd03c337ac3b933b0d9ae827ec32fa1fdcdbf",
+    "zh:bab66af51039bdfcccf85b25fe562cbba2f54f6b3812202f4873ade834ec201d",
+    "zh:c505ff1bf9442a889ac7dca3ac05a8ee6f852e0118dd9a61796a2f6ff4837f09",
+    "zh:d36c0b5770841ddb6eaf0499ba3de48e5d4fc99f4829b6ab66b0fab59b1aaf4f",
+    "zh:ddb6a407c7f3ec63efb4dad5f948b54f7f4434ee1a2607a49680d494b1776fe1",
+    "zh:e0dafdd4500bec23d3ff221e3a9b60621c5273e5df867bc59ef6b7e41f5c91f6",
+    "zh:ece8742fd2882a8fc9d6efd20e2590010d43db386b920b2a9c220cfecc18de47",
+    "zh:f4c6b3eb8f39105004cf720e202f04f57e3578441cfb76ca27611139bc116a82",
+  ]
+}

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -14,4 +14,5 @@ terraform(
     string(variable: 'DIGITALOCEAN_ACCESS_TOKEN', credentialsId:'production-terraform-digitalocean-pat'),
     file(variable: 'BACKEND_CONFIG_FILE', credentialsId: 'production-terraform-digitalocean-backend-config'),
   ],
+  publishReports: ['jenkins-infra-data-reports/digitalocean.json'],
 )

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,21 @@
+resource "local_file" "jenkins_infra_data_report" {
+  content = jsonencode({
+    "archives.jenkins.io" = {
+      # https://docs.digitalocean.com/products/networking/dns/getting-started/dns-registrars/
+      "name_servers" = [
+        "ns1.digitalocean.com",
+        "ns2.digitalocean.com",
+        "ns3.digitalocean.com",
+      ],
+      "outbound_ips" = {
+        "ipv4" = digitalocean_droplet.archives_jenkins_io.ipv4_address,
+        "ipv6" = digitalocean_droplet.archives_jenkins_io.ipv6_address,
+      },
+    },
+
+  })
+  filename = "${path.module}/jenkins-infra-data-reports/digitalocean.json"
+}
+output "jenkins_infra_data_report" {
+  value = local_file.jenkins_infra_data_report.content
+}

--- a/versions.tf
+++ b/versions.tf
@@ -4,5 +4,8 @@ terraform {
     digitalocean = {
       source = "digitalocean/digitalocean"
     }
+    local = {
+      source = "hashicorp/local"
+    }
   }
 }


### PR DESCRIPTION
We expect the report in https://reports.jenkins.io/jenkins-infra-data-reports/digitalocean.json