### PR TITLE
chore(outputs) ensure usage.do.jenkins.io informations are published …

### DIFF
--- a/archives.jenkins.io.tf
+++ b/archives.jenkins.io.tf
@@ -20,13 +20,13 @@ resource "digitalocean_volume_attachment" "archives_jenkins_io_data" {
 resource "digitalocean_droplet" "archives_jenkins_io" {
   # default username is root. TODO change it with cloudinit
   image       = "ubuntu-22-04-x64"
-  name        = "archives.jenkins.io"
+  name        = local.archives_jenkins_io_vmname
   region      = var.region
   size        = "s-4vcpu-8gb"
   monitoring  = true
   ipv6        = true
   resize_disk = true
   ssh_keys    = [digitalocean_ssh_key.archives_jenkins_io.fingerprint]
-  user_data   = templatefile("${path.root}/cloudinit.tftpl", { hostname = "archives.do.jenkins.io" })
+  user_data   = templatefile("${path.root}/cloudinit.tftpl", { hostname = local.archives_jenkins_io_fqdn })
   tags        = concat([for key, value in local.default_tags : "${key}:${value}"])
 }

--- a/dns.tf
+++ b/dns.tf
@@ -8,14 +8,14 @@ resource "digitalocean_domain" "do_jenkins_io" {
 resource "digitalocean_record" "archives_ipv4" {
   domain = digitalocean_domain.do_jenkins_io.id
   type   = "A"
-  name   = "archives"
+  name   = local.archives_jenkins_io_vmname
   value  = digitalocean_droplet.archives_jenkins_io.ipv4_address
 }
 
 resource "digitalocean_record" "archives_ipv6" {
   domain = digitalocean_domain.do_jenkins_io.id
   type   = "AAAA"
-  name   = "archives"
+  name   = local.archives_jenkins_io_vmname
   value  = digitalocean_droplet.archives_jenkins_io.ipv6_address
 }
 

--- a/locals.tf
+++ b/locals.tf
@@ -10,6 +10,12 @@ locals {
     jenkins_infra_repository = "digitalocean"
   }
 
+  usage_jenkins_io_vmname = "usage"
+  usage_jenkins_io_fqdn   = "${local.usage_jenkins_io_vmname}.${digitalocean_domain.do_jenkins_io.name}"
+
+  archives_jenkins_io_vmname = "archives"
+  archives_jenkins_io_fqdn   = "${local.archives_jenkins_io_vmname}.${digitalocean_domain.do_jenkins_io.name}"
+
   # Tracked by 'updatecli' from the following source: https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
   outbound_ips_private_vpn_jenkins_io = "52.232.183.117"
   # Tracked by 'updatecli' from the following source: https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,12 +1,15 @@
 resource "local_file" "jenkins_infra_data_report" {
   content = jsonencode({
-    "archives.jenkins.io" = {
+    "do.jenkins.io" = {
       # https://docs.digitalocean.com/products/networking/dns/getting-started/dns-registrars/
       "name_servers" = [
         "ns1.digitalocean.com",
         "ns2.digitalocean.com",
         "ns3.digitalocean.com",
       ],
+    }
+    "archives.jenkins.io" = {
+      "vm_dns_name" = local.archives_jenkins_io_fqdn
       "service_ips" = {
         "ipv4" = digitalocean_droplet.archives_jenkins_io.ipv4_address,
         "ipv6" = digitalocean_droplet.archives_jenkins_io.ipv6_address,
@@ -16,10 +19,15 @@ resource "local_file" "jenkins_infra_data_report" {
         "ipv6" = digitalocean_droplet.archives_jenkins_io.ipv6_address,
       },
     },
-    "jay.training" = {
+    "usage.jenkins.io" = {
+      "vm_dns_name" = local.usage_jenkins_io_fqdn,
       "service_ips" = {
-        "ipv4" = digitalocean_droplet.jay_training.ipv4_address,
-        "ipv6" = digitalocean_droplet.jay_training.ipv6_address,
+        "ipv4" = digitalocean_droplet.usage_jenkins_io.ipv4_address,
+        "ipv6" = digitalocean_droplet.usage_jenkins_io.ipv6_address,
+      },
+      "outbound_ips" = {
+        "ipv4" = digitalocean_droplet.usage_jenkins_io.ipv4_address,
+        "ipv6" = digitalocean_droplet.usage_jenkins_io.ipv6_address,
       },
     },
   })

--- a/usage.jenkins.io.tf
+++ b/usage.jenkins.io.tf
@@ -17,9 +17,6 @@ resource "digitalocean_volume_attachment" "usage_jenkins_io_data" {
   volume_id  = digitalocean_volume.usage_jenkins_io_data.id
 }
 
-locals {
-  usage_jenkins_io_vmname = "usage"
-}
 resource "digitalocean_droplet" "usage_jenkins_io" {
   # default username is root. TODO change it with cloudinit
   image       = "ubuntu-22-04-x64"
@@ -30,6 +27,6 @@ resource "digitalocean_droplet" "usage_jenkins_io" {
   ipv6        = true
   resize_disk = true
   ssh_keys    = [digitalocean_ssh_key.usage_jenkins_io.fingerprint]
-  user_data   = templatefile("${path.root}/cloudinit/usage-cloudinit.tftpl", { hostname = "${local.usage_jenkins_io_vmname}.${digitalocean_domain.do_jenkins_io.name}" })
+  user_data   = templatefile("${path.root}/cloudinit/usage-cloudinit.tftpl", { hostname = local.usage_jenkins_io_fqdn })
   tags        = concat([for key, value in local.default_tags : "${key}:${value}"], ["usage_jenkins_io"])
 }


### PR DESCRIPTION
This PR exposes the usage.jenkins.io information as part of https://github.com/jenkins-infra/helpdesk/issues/1626

It will allow docker-openvpn (and eventually other systems) to track the new IP and avoid PRS such as https://github.com/jenkins-infra/docker-openvpn/pull/464.

Note: also applies the same 'locals' technique for both VMs of usage and archives. The VM name for archives will be changed (no impact: it is only a metadata).